### PR TITLE
feat: Improve qml API

### DIFF
--- a/examples/qml-example/qml/minervous/streamdeck/example/QmlDeckExample.qml
+++ b/examples/qml-example/qml/minervous/streamdeck/example/QmlDeckExample.qml
@@ -3,7 +3,7 @@ import QtQuick.Controls
 import QtQuick.Layouts
 import minervous.streamdeck
 
-Window {
+ApplicationWindow {
 	id: root
 
 	property Window childWindow
@@ -12,9 +12,6 @@ Window {
 	minimumHeight: Math.max(content.implicitHeight + 20, 300)
 	visible: true
 	title: qsTr('Example Project')
-	color: '#f9f1cb'
-	palette.windowText: 'black'
-	palette.text: 'black'
 
 	function deviceTypeToString(type)
 	{
@@ -210,8 +207,9 @@ Window {
 
 					Image {
 						anchors.fill: parent
-						source: index === deck.animatedKeyIndex ? deck.grabbedUrl : (deck.buttonsState[index] ? deck.pressedImage :
-																												deck.normalImage)
+						source: index < keyModel.count
+								? (keyModel.at(index).image ? keyModel.at(index).imageAsUrl() : keyModel.at(index).imageSource)
+								: ''
 					}
 
 					Rectangle {

--- a/extensions/minervous.streamdeck/src/QmlStreamDeckKeyEntry.hpp
+++ b/extensions/minervous.streamdeck/src/QmlStreamDeckKeyEntry.hpp
@@ -3,6 +3,7 @@
 #include <QtQml/QQmlEngine>
 
 #include "minervous/streamdeck/BaseKeyEntry.hpp"
+#include "minervous/streamdeck/ImageHelper.hpp"
 
 namespace minervous::streamdeck
 {
@@ -26,7 +27,16 @@ namespace minervous::streamdeck
 			: Base{parent}
 		{}
 
-		QVariant image() const { return {Base::image()}; }
+		QVariant image() const
+		{
+			const auto & img = Base::image();
+			if (img.isNull())
+			{
+				return {};
+			}
+
+			return {img};
+		}
 
 		void setImage(QVariant v)
 		{
@@ -39,6 +49,8 @@ namespace minervous::streamdeck
 				Base::setImage({});
 			}
 		}
+
+		Q_INVOKABLE QUrl imageAsUrl() const { return ImageHelper::imageToUrl(Base::image()); }
 
 	signals:
 		void qmlDataChanged();

--- a/libs/streamdeck/include/minervous/streamdeck/BaseKeyEntry.hpp
+++ b/libs/streamdeck/include/minervous/streamdeck/BaseKeyEntry.hpp
@@ -28,7 +28,7 @@ namespace minervous::streamdeck
 		~BaseKeyEntry() override = default;
 
 		QUrl imageSource() const;
-		ImageType image() const;
+		const ImageType & image() const;
 		bool pressed() const;
 
 		void setImageSource(QUrl url);

--- a/libs/streamdeck/include/minervous/streamdeck/ImageHelper.hpp
+++ b/libs/streamdeck/include/minervous/streamdeck/ImageHelper.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <QtCore/QByteArray>
+#include <QtCore/QUrl>
+#include <QtGui/QImage>
+
+#include "StreamDeckLib_global.hpp"
+
+namespace minervous::streamdeck
+{
+	class STREAMDECKLIB_EXPORT ImageHelper
+	{
+	public:
+		static void imageToPngData(const QImage & image, QByteArray & array);
+		static QUrl pngDataToUrl(const QByteArray & array);
+		static QUrl imageToUrl(const QImage & image);
+	};
+
+}  // namespace minervous::streamdeck

--- a/libs/streamdeck/src/BaseKeyEntry.cpp
+++ b/libs/streamdeck/src/BaseKeyEntry.cpp
@@ -16,7 +16,7 @@ QUrl BaseKeyEntry::imageSource() const
 	return _imageSource;
 }
 
-BaseKeyEntry::ImageType BaseKeyEntry::image() const
+const BaseKeyEntry::ImageType & BaseKeyEntry::image() const
 {
 	return _image;
 }

--- a/libs/streamdeck/src/DeviceEmulator.cpp
+++ b/libs/streamdeck/src/DeviceEmulator.cpp
@@ -7,6 +7,7 @@
 
 #include "DeviceId.hpp"
 #include "DeviceManager.hpp"
+#include "ImageHelper.hpp"
 #include "devices/StreamDeckMini.hpp"
 #include "devices/StreamDeckOriginal.hpp"
 #include "devices/StreamDeckOriginalV2.hpp"
@@ -153,10 +154,8 @@ struct DeviceEmulator::Impl
 					.mirrored(emulator._configuration.imageHorizontalFlip, emulator._configuration.imageVerticalFlip);
 
 			QByteArray data;
-			QBuffer buffer{&data};
-			image.save(&buffer, "PNG", 100);
-
-			QString base64 = data.size() > 0 ? u"data:image/png;base64,%1"_s.arg(data.toBase64()) : "";
+			ImageHelper::imageToPngData(image, data);
+			QString base64 = ImageHelper::pngDataToUrl(data).toString();
 
 			emit emulator._device.imageSent(keyIndex, data, base64);
 			return true;

--- a/libs/streamdeck/src/ImageHelper.cpp
+++ b/libs/streamdeck/src/ImageHelper.cpp
@@ -1,0 +1,24 @@
+#include "ImageHelper.hpp"
+
+#include <QtCore/QBuffer>
+
+using namespace minervous::streamdeck;
+using namespace Qt::Literals;
+
+void ImageHelper::imageToPngData(const QImage & image, QByteArray & array)
+{
+	QBuffer buffer{&array};
+	image.save(&buffer, "PNG", 100);
+}
+
+QUrl ImageHelper::pngDataToUrl(const QByteArray & array)
+{
+	return array.size() > 0 ? u"data:image/png;base64,%1"_s.arg(array.toBase64()) : "";
+}
+
+QUrl ImageHelper::imageToUrl(const QImage & image)
+{
+	QByteArray data;
+	imageToPngData(image, data);
+	return pngDataToUrl(data);
+}


### PR DESCRIPTION
Allow usage of StreamDeckEntry.image data (cpp QImage inside) in qml via Entry.imageAsUrl() function.
Now it can be set to source for qml Image